### PR TITLE
Fix for describe caching

### DIFF
--- a/zkSforce/zkSforceClient.m
+++ b/zkSforce/zkSforceClient.m
@@ -53,6 +53,7 @@ static const int SAVE_BATCH_SIZE = 25;
 	[self setLoginProtocolAndHost:@"https://www.salesforce.com"];
 	updateMru = NO;
 	cacheDescribes = NO;
+	describes = [[NSMutableDictionary alloc] init];
 	return self;
 }
 


### PR DESCRIPTION
Since moving cacheDescribes to an @property, the describes NSMutableDictionary is no longer initialized.
