### PR TITLE
Nil check before adding to cached values

### DIFF
--- a/zkSforce/zkXmlDeserializer.m
+++ b/zkSforce/zkXmlDeserializer.m
@@ -100,7 +100,9 @@
     if (cached == nil) {
         NSString *b64 = [self string:elem fromXmlElement:node];
         cached = [b64 ZKBase64Decode];
-        [values setObject:cached forKey:elem];
+
+        if (cached != nil)
+        	[values setObject:cached forKey:elem];
     }
     return cached;
 }


### PR DESCRIPTION
Crashing when validFor picklistEntry value is not set a.k.a. the dependant picklist entry is not valid for any controller field picklist entry. Had to add a nil check before adding the new value to the cached values dictionary.