### PR TITLE
Add header tag if clientId is null

### DIFF
--- a/zkSforce/zkAuthentication.m
+++ b/zkSforce/zkAuthentication.m
@@ -226,7 +226,12 @@ static const int DEFAULT_MAX_SESSION_AGE = 25 * 60; // 25 minutes
 
 -(ZKPartnerEnvelope *)newEnvelope {
     ZKPartnerEnvelope *env = [[ZKPartnerEnvelope alloc] initWithSessionHeader:nil];
-    [env writeCallOptionsHeader:clientId];
+    
+    if (clientId != nil)
+        [env writeCallOptionsHeader:clientId];
+    else
+        [env moveToHeaders];
+    
     [env startElement:@"LoginScopeHeader"];
     [env addElement:@"organizationId" elemValue:orgId];
     if ([portalId length] > 0)


### PR DESCRIPTION
If clientId is null during Portal Login, the header tag will not be added around LoginScopeHeader. The request therefore errors out.