### PR TITLE
One more fix for ZKEnvelope

### DIFF
--- a/zkSforce/zkEnvelope.m
+++ b/zkSforce/zkEnvelope.m
@@ -174,7 +174,7 @@ enum envState {
     if (state == inBody)
         [self endElement:@"s:Body"];
     [self endElement:@"s:Envelope"];
-	return env;
+    return [[env retain] autorelease];
 }
 
 @end


### PR DESCRIPTION
I understood why there was no zombie. You used `env` before `autorelease` had place.

Sorry, but we need one more fix 😳 But now everthing is OK, I think.